### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gulp.task('clean', function() {
 <br>PS: As of now you can't pipe it with other plugins or use regular expressions
 
 ## Note
-`This package is process of being created. Please be patient. Feel free to contribute if you like.`
+`This package is in process of being created. Please be patient. Feel free to contribute if you like.`
 
 ## TODO
 * List all files and folders deleted if option verbose is passed


### PR DESCRIPTION
Fixed grammar typo. "To be in process" means it is being currently worked upon. "To be process" means it is a process of, for example, readlibdll is a Linux system process.
